### PR TITLE
Allow setting the max resolution of the output video

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -24,6 +24,8 @@ void Recorder::SetOptions(RecorderOptions^ options) {
 			lRec->SetFixedFramerate(options->VideoOptions->IsFixedFramerate);
 			lRec->SetH264EncoderProfile((UINT32)options->VideoOptions->EncoderProfile);
 			lRec->SetVideoBitrateMode((UINT32)options->VideoOptions->BitrateMode);
+			lRec->SetMaxVideoHeight((UINT32)options->VideoOptions->MaxHeight);
+			lRec->SetMaxVideoWidth((UINT32)options->VideoOptions->MaxWidth);
 			switch (options->VideoOptions->SnapshotFormat)
 			{
 			case ImageFormat::BMP:

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -136,6 +136,8 @@ namespace ScreenRecorderLib {
 			EncoderProfile = H264Profile::Baseline;
 			BitrateMode = BitrateControlMode::Quality;
 			SnapshotFormat = ImageFormat::PNG;
+			MaxHeight = 0;
+			MaxWidth = 0;
 		}
 		property H264Profile EncoderProfile;
 		/// <summary>
@@ -162,6 +164,14 @@ namespace ScreenRecorderLib {
 		///Image format for snapshots. This is only used with Snapshot and Slideshow modes.
 		/// </summary>
 		property ImageFormat SnapshotFormat;
+		/// <summary>
+		/// Maximum width, in pixels, of the output video 
+		/// </summary>
+		property int MaxWidth;	
+		/// <summary>
+		/// Maximum height, in pixels, of the output video;
+		/// </summary>
+		property int MaxHeight;
 	};
 	public ref class AudioOptions {
 	public:

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -209,6 +209,16 @@ void internal_recorder::SetSnapshotSaveFormat(GUID value) {
 	m_ImageEncoderFormat = value;
 }
 
+void internal_recorder::SetMaxVideoWidth(UINT32 value)
+{
+	m_MaxVideoWidth = value;
+}
+
+void internal_recorder::SetMaxVideoHeight(UINT32 value)
+{
+	m_MaxVideoHeight = value;
+}
+
 std::vector<BYTE> internal_recorder::MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second)
 {
 	std::vector<BYTE> newvector;
@@ -1242,6 +1252,20 @@ HRESULT internal_recorder::InitializeVideoSinkWriter(std::wstring path, _In_opt_
 	UINT destWidth = max(0, destRect.right - destRect.left);
 	UINT destHeight = max(0, destRect.bottom - destRect.top);
 
+	UINT outputWidth = destWidth, outputHeight = destHeight;
+	if (m_MaxVideoHeight != 0 || m_MaxVideoWidth != 0) {
+		double aspect = (double)destWidth / (double)destHeight;
+
+		if (m_MaxVideoWidth != 0 && destWidth > m_MaxVideoWidth) {
+			outputHeight = m_MaxVideoWidth / aspect;
+			outputWidth = m_MaxVideoWidth;
+		}
+		else if(m_MaxVideoHeight != 0 && destHeight > m_MaxVideoHeight){
+			outputWidth = m_MaxVideoHeight * aspect;
+			outputHeight = m_MaxVideoHeight;
+		}
+	}
+
 	// Set the output video type.
 	RETURN_ON_BAD_HR(MFCreateMediaType(&pVideoMediaTypeOut));
 	RETURN_ON_BAD_HR(pVideoMediaTypeOut->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
@@ -1250,7 +1274,7 @@ HRESULT internal_recorder::InitializeVideoSinkWriter(std::wstring path, _In_opt_
 	RETURN_ON_BAD_HR(pVideoMediaTypeOut->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
 	RETURN_ON_BAD_HR(pVideoMediaTypeOut->SetUINT32(MF_MT_MPEG2_PROFILE, m_H264Profile));
 	RETURN_ON_BAD_HR(pVideoMediaTypeOut->SetUINT32(MF_MT_YUV_MATRIX, MFVideoTransferMatrix_BT601));
-	RETURN_ON_BAD_HR(MFSetAttributeSize(pVideoMediaTypeOut, MF_MT_FRAME_SIZE, destWidth, destHeight));
+	RETURN_ON_BAD_HR(MFSetAttributeSize(pVideoMediaTypeOut, MF_MT_FRAME_SIZE, outputWidth, outputHeight));
 	RETURN_ON_BAD_HR(MFSetAttributeRatio(pVideoMediaTypeOut, MF_MT_FRAME_RATE, m_VideoFps, 1));
 	RETURN_ON_BAD_HR(MFSetAttributeRatio(pVideoMediaTypeOut, MF_MT_PIXEL_ASPECT_RATIO, 1, 1));
 

--- a/ScreenRecorderLib/internal_recorder.h
+++ b/ScreenRecorderLib/internal_recorder.h
@@ -58,8 +58,8 @@ public:
 	CallbackCompleteFunction RecordingCompleteCallback;
 	CallbackStatusChangedFunction RecordingStatusChangedCallback;
 	HRESULT BeginRecording(std::wstring path);
-	HRESULT BeginRecording(std::wstring path, IStream * stream);
-	HRESULT BeginRecording(IStream *stream);
+	HRESULT BeginRecording(std::wstring path, IStream* stream);
+	HRESULT BeginRecording(IStream* stream);
 	std::vector<ATL::CComPtr<IDXGIAdapter>> EnumDisplayAdapters();
 	void EndRecording();
 	void PauseRecording();
@@ -95,6 +95,8 @@ public:
 	void SetMouseClickDetectionDuration(int value);
 	void SetMouseClickDetectionMode(UINT32 value);
 	void SetSnapshotSaveFormat(GUID value);
+	void SetMaxVideoWidth(UINT32 value);
+	void SetMaxVideoHeight(UINT32 value);
 
 private:
 	// Format constants
@@ -157,6 +159,8 @@ private:
 	UINT32 m_MouseClickDetectionRadius = 20;
 	UINT32 m_MouseClickDetectionMode = MOUSE_DETECTION_MODE_POLLING;
 	GUID m_ImageEncoderFormat = GUID_ContainerFormatPng;
+	UINT32 m_MaxVideoWidth = 0;
+	UINT32 m_MaxVideoHeight = 0;
 
 	//functions
 	std::string CurrentTimeToFormattedString();

--- a/TestApp/MainWindow.xaml
+++ b/TestApp/MainWindow.xaml
@@ -98,7 +98,16 @@
                              VerticalContentAlignment="Center"
                              GotFocus="TextBox_GotFocus"
                              MinWidth="30" />
-
+                    <Label Content="w" />
+                    <TextBox x:Name="RecordingAreaMaxWidthTextBox"
+                             VerticalContentAlignment="Center"
+                             GotFocus="TextBox_GotFocus"
+                             MinWidth="30" />
+                    <Label Content="h" />
+                    <TextBox x:Name="RecordingAreaMaxHeightTextBox"
+                             VerticalContentAlignment="Center"
+                             GotFocus="TextBox_GotFocus"
+                             MinWidth="30" />
                 </StackPanel>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/TestApp/MainWindow.xaml.cs
+++ b/TestApp/MainWindow.xaml.cs
@@ -213,6 +213,10 @@ namespace TestApp
             Int32.TryParse(this.RecordingAreaLeftTextBox.Text, out left);
             int top = 0;
             Int32.TryParse(this.RecordingAreaTopTextBox.Text, out top);
+            int maxWidth = 0;
+            Int32.TryParse(this.RecordingAreaMaxWidthTextBox.Text, out maxWidth);
+            int maxHeight = 0;
+            Int32.TryParse(this.RecordingAreaMaxHeightTextBox.Text, out maxHeight);
 
             Display selectedDisplay = (Display)this.ScreenComboBox.SelectedItem;
 
@@ -245,7 +249,9 @@ namespace TestApp
                     Quality = this.VideoQuality,
                     IsFixedFramerate = this.IsFixedFramerate,
                     EncoderProfile = this.CurrentH264Profile,
-                    SnapshotFormat = CurrentImageFormat
+                    SnapshotFormat = CurrentImageFormat,
+                    MaxWidth = maxWidth,
+                    MaxHeight = maxHeight,
                 },
                 DisplayOptions = new DisplayOptions(selectedDisplay.DisplayName, left, top, right, bottom),
                 MouseOptions = new MouseOptions


### PR DESCRIPTION
Add the following fields to the `VideoOptions` 

* `MaxWidth` Maximum output video width
* `MaxHeight` Maximum output video height

Whichever of these options that is set constraints the other if the corresponding parameter of the output video, according to the aspect ration of the selected recording rectangle.