### PR TITLE
Expose the default audio device ID

### DIFF
--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -146,22 +146,15 @@ String^ Recorder::GetSystemDefaultAudioDevice(AudioDeviceSource source) {
 		break;
 	}
 
-	IMMDevice* pMMDevice;
-	HRESULT hr = get_default_device(&pMMDevice, dFlow);
+	
+	std::wstring id;
+	HRESULT hr = get_default_device_id(dFlow, &id);
 
-	if (FAILED(hr)) {
-		ERROR(L"get_default_device failed: hr = 0x%08x", hr);
-		return nullptr;
+	if (hr == S_OK) {
+		return gcnew String(id.c_str());
 	}
 
-	LPWSTR deviceID = L"";
-	hr = pMMDevice->GetId(&deviceID);
-	if (FAILED(hr)) {
-		ERROR(L"IMMDevice->GetId(deviceID) failed: hr = 0x%08x", hr);
-		return nullptr;
-	}
-
-	return gcnew String(deviceID);
+	return gcnew String("");
 }
 
 Recorder::~Recorder()

--- a/ScreenRecorderLib/Recorder.cpp
+++ b/ScreenRecorderLib/Recorder.cpp
@@ -6,6 +6,8 @@
 #include "cleanup.h"
 #include "ManagedIStream.h"
 #include "internal_recorder.h"
+#include "audio_prefs.h"
+
 using namespace ScreenRecorderLib;
 using namespace nlohmann;
 
@@ -125,6 +127,41 @@ Dictionary<String^, String^>^ Recorder::GetSystemAudioDevices(AudioDeviceSource 
 		}
 	}
 	return devices;
+}
+
+String^ Recorder::GetSystemDefaultAudioDevice(AudioDeviceSource source) {
+	EDataFlow dFlow;
+
+	switch (source)
+	{
+	default:
+	case  AudioDeviceSource::OutputDevices:
+		dFlow = eRender;
+		break;
+	case AudioDeviceSource::InputDevices:
+		dFlow = eCapture;
+		break;
+	case AudioDeviceSource::All:
+		dFlow = eAll;
+		break;
+	}
+
+	IMMDevice* pMMDevice;
+	HRESULT hr = get_default_device(&pMMDevice, dFlow);
+
+	if (FAILED(hr)) {
+		ERROR(L"get_default_device failed: hr = 0x%08x", hr);
+		return nullptr;
+	}
+
+	LPWSTR deviceID = L"";
+	hr = pMMDevice->GetId(&deviceID);
+	if (FAILED(hr)) {
+		ERROR(L"IMMDevice->GetId(deviceID) failed: hr = 0x%08x", hr);
+		return nullptr;
+	}
+
+	return gcnew String(deviceID);
 }
 
 Recorder::~Recorder()

--- a/ScreenRecorderLib/Recorder.h
+++ b/ScreenRecorderLib/Recorder.h
@@ -367,6 +367,7 @@ namespace ScreenRecorderLib {
 		static Recorder^ CreateRecorder();
 		static Recorder^ CreateRecorder(RecorderOptions^ options);
 		static Dictionary<String^, String^>^ GetSystemAudioDevices(AudioDeviceSource source);
+		static String^ GetSystemDefaultAudioDevice(AudioDeviceSource source);
 		event EventHandler<RecordingCompleteEventArgs^>^ OnRecordingComplete;
 		event EventHandler<RecordingFailedEventArgs^>^ OnRecordingFailed;
 		event EventHandler<RecordingStatusEventArgs^>^ OnStatusChanged;

--- a/ScreenRecorderLib/audio_prefs.cpp
+++ b/ScreenRecorderLib/audio_prefs.cpp
@@ -12,6 +12,7 @@
 #include "cleanup.h"
 
 
+HRESULT get_default_device(IMMDevice** ppMMDevice, EDataFlow flow);
 HRESULT get_specific_device(LPCWSTR szDeviceId, EDataFlow flow, IMMDevice **ppMMDevice);
 HRESULT open_file(LPCWSTR szFileName, HMMIO *phFile);
 
@@ -113,6 +114,30 @@ HRESULT get_default_device(IMMDevice **ppMMDevice, EDataFlow flow) {
 		ERROR(L"IMMDeviceEnumerator::GetDefaultAudioEndpoint failed: hr = 0x%08x", hr);
 		return hr;
 	}
+
+	return S_OK;
+}
+
+HRESULT get_default_device_id(EDataFlow flow, std::wstring* id) 
+{
+	IMMDevice* pMMDevice;
+	HRESULT hr = get_default_device(&pMMDevice, flow);
+
+	if (FAILED(hr)) {
+		ERROR(L"get_default_device failed: hr = 0x%08x", hr);
+		return hr;
+	}
+
+	ReleaseOnExit releaseMMDevice(pMMDevice);
+
+	LPWSTR deviceID = L"";
+	hr = pMMDevice->GetId(&deviceID);
+	if (FAILED(hr)) {
+		ERROR(L"IMMDevice->GetId(deviceID) failed: hr = 0x%08x", hr);
+		return hr;
+	}
+
+	*id = deviceID;
 
 	return S_OK;
 }

--- a/ScreenRecorderLib/audio_prefs.cpp
+++ b/ScreenRecorderLib/audio_prefs.cpp
@@ -12,9 +12,6 @@
 #include "cleanup.h"
 
 
-
-
-HRESULT get_default_device(IMMDevice **ppMMDevice, EDataFlow flow);
 HRESULT get_specific_device(LPCWSTR szDeviceId, EDataFlow flow, IMMDevice **ppMMDevice);
 HRESULT open_file(LPCWSTR szFileName, HMMIO *phFile);
 

--- a/ScreenRecorderLib/audio_prefs.h
+++ b/ScreenRecorderLib/audio_prefs.h
@@ -17,3 +17,5 @@ public:
 	// writes all found devices for chosen flow into devices
 	static HRESULT list_devices(EDataFlow flow, std::map<std::wstring, std::wstring>* devices);
 };
+
+HRESULT get_default_device(IMMDevice** ppMMDevice, EDataFlow flow);

--- a/ScreenRecorderLib/audio_prefs.h
+++ b/ScreenRecorderLib/audio_prefs.h
@@ -18,4 +18,4 @@ public:
 	static HRESULT list_devices(EDataFlow flow, std::map<std::wstring, std::wstring>* devices);
 };
 
-HRESULT get_default_device(IMMDevice** ppMMDevice, EDataFlow flow);
+HRESULT get_default_device_id(EDataFlow flow, std::wstring* id);


### PR DESCRIPTION
Add a method to the Recorder object to expose the id of the default system audio device.

https://app.asana.com/0/409657064241888/1195713114073408/f