### PR TITLE
Mix audio correctly

### DIFF
--- a/ScreenRecorderLib/WWMFResampler.cpp
+++ b/ScreenRecorderLib/WWMFResampler.cpp
@@ -84,6 +84,19 @@ CreateResamplerMFT(
 	RETURN_ON_BAD_HR(spTransformUnk->QueryInterface(IID_PPV_ARGS(&spResamplerProps)));
 	RETURN_ON_BAD_HR(spResamplerProps->SetHalfFilterLength(halfFilterLength));
 
+	/* Not sure we _need_ this (as in, it may be done automatically),
+	 * but I'll keep it around until demonstrated otherwise */
+#if RESAMPLER_NEEDS_LOWPASS_FILTER
+	/* Set up a low-pass filter at half of the 
+	 * output sample rate */
+	CComPtr<IPropertyStore> propStore;
+	RETURN_ON_BAD_HR(spTransformUnk->QueryInterface(IID_PPV_ARGS(&propStore)));
+	PROPVARIANT value;
+	value.vt = VT_R4;
+	value.fltVal = 0.5;
+	RETURN_ON_BAD_HR(propStore->SetValue(MFPKEY_WMRESAMP_LOWPASS_BANDWIDTH, value));
+#endif
+
 	*ppTransform = pTransform;
 	(*ppTransform)->AddRef();
 

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -239,9 +239,10 @@ void internal_recorder::SetMaxVideoHeight(UINT32 value)
 
 std::vector<BYTE> internal_recorder::MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second)
 {
+	using vect_size = std::vector<BYTE>::size_type;
 	std::vector<BYTE> newvector;
 
-	size_t smaller;
+	vect_size smaller;
 
 	if (first.size() >= second.size())
 	{
@@ -254,7 +255,7 @@ std::vector<BYTE> internal_recorder::MixAudio(std::vector<BYTE> &first, std::vec
 		smaller = first.size();
 	}
 
-	for (int i = 0; i < smaller; i += 2) {
+	for (vect_size i = 0; i < smaller; i += 2) {
 		short buf1A = first[i + 1];
 		short buf2A = first[i];
 		buf1A = (short)((buf1A & 0xff) << 8);
@@ -273,7 +274,7 @@ std::vector<BYTE> internal_recorder::MixAudio(std::vector<BYTE> &first, std::vec
 		newvector[i] = (BYTE)res;
 		newvector[i + 1] = (BYTE)(res >> 8);
 	}
-
+	
 	return newvector;
 }
 

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -366,6 +366,9 @@ HRESULT internal_recorder::BeginRecording(std::wstring path) {
 
 HRESULT internal_recorder::BeginRecording(std::wstring path, IStream *stream) {
 
+	// Clean any previous leftovers.
+	previousMixData = mix_data();
+
 	if (!IsWindows8OrGreater()) {
 		wstring errorText = L"Windows 8 or higher is required";
 		ERROR(L"%ls", errorText);

--- a/ScreenRecorderLib/internal_recorder.cpp
+++ b/ScreenRecorderLib/internal_recorder.cpp
@@ -254,7 +254,7 @@ mix_data internal_recorder::MixAudio(std::vector<BYTE>& first, std::vector<BYTE>
 	buffer_type newBuffer;
 	newBuffer.resize(shorterBufferSize);
 
-	// Keep a ref to the shorter buffer
+	// Mix the samples in both buffers, but only until in the span covered by the shorter buffer
 	for (size_type i = 0; i < shorterBufferSize; i += 2) {
 		short firstSample = static_cast<short>(first[i] | first[i + 1] << 8);
 		short secondSample = static_cast<short>(second[i] | second[i + 1] << 8);

--- a/ScreenRecorderLib/internal_recorder.h
+++ b/ScreenRecorderLib/internal_recorder.h
@@ -49,6 +49,12 @@ typedef struct
 
 LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam);
 
+struct mix_data {
+	std::vector<BYTE> mix;
+	std::vector<BYTE> firstLeftover;
+	std::vector<BYTE> secondLeftover;
+};
+
 class internal_recorder
 {
 public:
@@ -119,6 +125,8 @@ private:
 	IMFSinkWriter *m_SinkWriter = nullptr;
 	ID3D11Device *m_Device = nullptr;
 
+	mix_data previousMixData;
+
 	bool m_LastFrameHadAudio = false;
 	HRESULT m_EncoderResult = S_FALSE;
 	HHOOK m_Mousehook;
@@ -170,7 +178,7 @@ private:
 	//functions
 	std::string CurrentTimeToFormattedString();
 	std::vector<BYTE> GrabAudioFrame(std::unique_ptr<loopback_capture>& pLoopbackCaptureOutputDevice, std::unique_ptr<loopback_capture>& pLoopbackCaptureInputDevice);
-	std::vector<BYTE> MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second);
+	mix_data MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second, mix_data const& prevMixData);
 	void SetDebugName(ID3D11DeviceChild* child, const std::string& name);
 	void SetViewPort(ID3D11DeviceContext *deviceContext, UINT Width, UINT Height);
 	std::wstring GetImageExtension();

--- a/ScreenRecorderLib/internal_recorder.h
+++ b/ScreenRecorderLib/internal_recorder.h
@@ -177,8 +177,8 @@ private:
 
 	//functions
 	std::string CurrentTimeToFormattedString();
-	std::vector<BYTE> GrabAudioFrame(std::unique_ptr<loopback_capture>& pLoopbackCaptureOutputDevice, std::unique_ptr<loopback_capture>& pLoopbackCaptureInputDevice);
-	mix_data MixAudio(std::vector<BYTE> &first, std::vector<BYTE> &second, mix_data const& prevMixData);
+	std::vector<BYTE> GrabAudioFrame(std::unique_ptr<loopback_capture>& pLoopbackCaptureOutputDevice, std::unique_ptr<loopback_capture>& pLoopbackCaptureInputDevice, bool isLastCall = false);
+	mix_data MixAudio(std::vector<BYTE>& first, std::vector<BYTE>& second, mix_data const& prevMixData, bool const isLastCall = true);
 	void SetDebugName(ID3D11DeviceChild* child, const std::string& name);
 	void SetViewPort(ID3D11DeviceContext *deviceContext, UINT Width, UINT Height);
 	std::wstring GetImageExtension();

--- a/ScreenRecorderLib/loopback_capture.cpp
+++ b/ScreenRecorderLib/loopback_capture.cpp
@@ -404,7 +404,6 @@ UINT32 loopback_capture::GetInputSampleRate() {
 
 bool loopback_capture::requiresResampling()
 {
-	return true;
 	return inputFormat.sampleRate != outputFormat.sampleRate || outputFormat.nChannels != inputFormat.nChannels;
 }
 

--- a/ScreenRecorderLib/loopback_capture.cpp
+++ b/ScreenRecorderLib/loopback_capture.cpp
@@ -283,10 +283,8 @@ HRESULT loopback_capture::LoopbackCapture(
 				continue; // exits loop
 			}
 
-			if (AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY == dwFlags) {
-				DEBUG(L"Discont!");
-				if(bFirstPacket)
-					DEBUG(L"Probably spurious glitch reported on first packet on %s", tag);
+			if (bFirstPacket && AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY == dwFlags) {
+				DEBUG(L"Probably spurious glitch reported on first packet on %s", tag);
 			}
 			else if (AUDCLNT_BUFFERFLAGS_SILENT == dwFlags) {
 				//INFO(L"IAudioCaptureClient::GetBuffer set flags to 0x%08x on pass %u after %u frames", dwFlags, nPasses, *pnFrames);

--- a/ScreenRecorderLib/loopback_capture.cpp
+++ b/ScreenRecorderLib/loopback_capture.cpp
@@ -283,8 +283,10 @@ HRESULT loopback_capture::LoopbackCapture(
 				continue; // exits loop
 			}
 
-			if (bFirstPacket && AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY == dwFlags) {
-				DEBUG(L"Probably spurious glitch reported on first packet on %s", tag);
+			if (AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY == dwFlags) {
+				DEBUG(L"Discont!");
+				if(bFirstPacket)
+					DEBUG(L"Probably spurious glitch reported on first packet on %s", tag);
 			}
 			else if (AUDCLNT_BUFFERFLAGS_SILENT == dwFlags) {
 				//INFO(L"IAudioCaptureClient::GetBuffer set flags to 0x%08x on pass %u after %u frames", dwFlags, nPasses, *pnFrames);
@@ -402,6 +404,7 @@ UINT32 loopback_capture::GetInputSampleRate() {
 
 bool loopback_capture::requiresResampling()
 {
+	return true;
 	return inputFormat.sampleRate != outputFormat.sampleRate || outputFormat.nChannels != inputFormat.nChannels;
 }
 


### PR DESCRIPTION
Turned out that the main reason behind [this bug](https://app.asana.com/0/409657064241888/1198875618488873/f) was that the audio mixing function was incorrect.

The input to `MixAudio` was two buffers: the input (let's call it A) and the system audio (B). The mixing routine was trying to sum all the samples from A with the corresponding samples in B, producing a new buffer, C. 

The problem is that, for unspecified reasons, A and B could have different lengths, and apparently this situation is specially prevalent when the _resampler_ in loopback_capture kicks in (any time the input/output sample rate, channel count does not match). `MixAudio` would then proceed to mix all of the shorter buffer into the longer one, _with the trailing data of the longer buffer at the end_. This meant that the contribution of the shorter buffer to the output mix would be _discontinuous_ (think that the input mic buffer is the shortest, and the other one, system audio, is silent) causing all kinds of aritfacts in the recorided audio.

This change does the only sane thing I could come up with: output the mix of the common length, and store the leftover for the next iteration in order to _preprend_ the data to the appropiate buffer, handling the case of the last call so that it appends any leftover too. 

I also simplified the mixing logic, because frankly, it was unreadable and was not doing anything super smart. In fact, I'm 95% sure it was _wrong_ due to a possible overflow and mishandling of the sign bit of the samples.